### PR TITLE
Enable Structure calculations

### DIFF
--- a/eos/const/eve.py
+++ b/eos/const/eve.py
@@ -180,7 +180,7 @@ class Category(IntEnum):
     implant = 20
     subsystem = 32
     structure = 65
-    structureModules = 66
+    structureModule = 66
 
 
 @unique

--- a/eos/const/eve.py
+++ b/eos/const/eve.py
@@ -33,7 +33,7 @@ class Attribute(IntEnum):
 
     # This is a static mapping of data from dmgattribs
     # if attribs are added/updated, this will have to be manually changed
-    
+
     mass = 4
     hp = 9
     power_output = 11
@@ -105,7 +105,7 @@ class Attribute(IntEnum):
     required_skill_5 = 1289
     required_skill_6 = 1290
 
-    #Ship Groups
+    # Ship Groups
     can_fit_ship_group_1 = 1298
     can_fit_ship_group_2 = 1299
     can_fit_ship_group_3 = 1300
@@ -117,7 +117,7 @@ class Attribute(IntEnum):
     can_fit_ship_group_9 = 2065
     can_fit_ship_group_10 = 2396
 
-    #Ship Types
+    # Ship Types
     can_fit_ship_type_1 = 1302
     can_fit_ship_type_2 = 1303
     can_fit_ship_type_3 = 1304

--- a/eos/const/eve.py
+++ b/eos/const/eve.py
@@ -30,6 +30,10 @@ from enum import IntEnum, unique
 @unique
 class Attribute(IntEnum):
     """Attribute ID holder"""
+
+    # This is a static mapping of data from dmgattribs
+    # if attribs are added/updated, this will have to be manually changed
+    
     mass = 4
     hp = 9
     power_output = 11
@@ -100,14 +104,28 @@ class Attribute(IntEnum):
     required_skill_6_level = 1288
     required_skill_5 = 1289
     required_skill_6 = 1290
+
+    #Ship Groups
     can_fit_ship_group_1 = 1298
     can_fit_ship_group_2 = 1299
     can_fit_ship_group_3 = 1300
     can_fit_ship_group_4 = 1301
+    can_fit_ship_group_5 = 1872
+    can_fit_ship_group_6 = 1879
+    can_fit_ship_group_7 = 1880
+    can_fit_ship_group_8 = 1881
+    can_fit_ship_group_9 = 2065
+    can_fit_ship_group_10 = 2396
+
+    #Ship Types
     can_fit_ship_type_1 = 1302
     can_fit_ship_type_2 = 1303
     can_fit_ship_type_3 = 1304
     can_fit_ship_type_4 = 1305
+    can_fit_ship_type_5 = 1944
+    can_fit_ship_type_6 = 2103
+    can_fit_ship_type_7 = 2463
+
     subsystem_slot = 1366
     max_subsystems = 1367
     fits_to_shiptype = 1380
@@ -116,10 +134,7 @@ class Attribute(IntEnum):
     allowed_drone_group_1 = 1782
     allowed_drone_group_2 = 1783
     reload_time = 1795
-    can_fit_ship_group_5 = 1872
-    can_fit_ship_group_6 = 1879
-    can_fit_ship_group_7 = 1880
-    can_fit_ship_group_8 = 1881
+
 
 
 @unique

--- a/eos/const/eve.py
+++ b/eos/const/eve.py
@@ -135,8 +135,6 @@ class Attribute(IntEnum):
     allowed_drone_group_2 = 1783
     reload_time = 1795
 
-
-
 @unique
 class Type(IntEnum):
     """Item ID holder"""
@@ -169,13 +167,19 @@ class Group(IntEnum):
 @unique
 class Category(IntEnum):
     """Category ID holder"""
+
+    # Mapping from invcategories
+
     ship = 6
     module = 7
     charge = 8
     skill = 16
     drone = 18
+    fighter = 87
     implant = 20
     subsystem = 32
+    structure = 65
+    structureModules = 66
 
 
 @unique

--- a/eos/const/eve.py
+++ b/eos/const/eve.py
@@ -135,6 +135,7 @@ class Attribute(IntEnum):
     allowed_drone_group_2 = 1783
     reload_time = 1795
 
+
 @unique
 class Type(IntEnum):
     """Item ID holder"""

--- a/eos/data/cache_generator/cleaner.py
+++ b/eos/data/cache_generator/cleaner.py
@@ -63,7 +63,10 @@ class Cleaner:
             Category.skill,
             Category.drone,
             Category.implant,
-            Category.subsystem
+            Category.subsystem,
+            Category.fighter,
+            Category.structure,
+            Category.structureModules
         )
         # Set with groupIDs of items we want to keep
         # It is set because we will need to modify it

--- a/eos/data/cache_generator/cleaner.py
+++ b/eos/data/cache_generator/cleaner.py
@@ -66,7 +66,7 @@ class Cleaner:
             Category.subsystem,
             Category.fighter,
             Category.structure,
-            Category.structureModules
+            Category.structureModule
         )
         # Set with groupIDs of items we want to keep
         # It is set because we will need to modify it

--- a/eos/fit/restriction_tracker/register/holder_class.py
+++ b/eos/fit/restriction_tracker/register/holder_class.py
@@ -49,22 +49,29 @@ CLASS_VALIDATORS = {
         Attribute.implantness in item.attributes
     ),
     ModuleHigh: lambda item: (
-        item.category == Category.module and
+        (item.category == Category.module or
+         item.category == Category.structureModule) and
         Slot.module_high in item.slots
     ),
     ModuleMed: lambda item: (
-        item.category == Category.module and
+        (item.category == Category.module or
+         item.category == Category.structureModule) and
         Slot.module_med in item.slots
     ),
     ModuleLow: lambda item: (
-        item.category == Category.module and
+        (item.category == Category.module or
+         item.category == Category.structureModule) and
         Slot.module_low in item.slots
     ),
     Rig: lambda item: (
-        item.category == Category.module and
+        (item.category == Category.module or
+         item.category == Category.structureModule) and
         Slot.rig in item.slots
     ),
-    Ship: lambda item: item.category == Category.ship,
+    Ship: lambda item: (
+        item.category == Category.ship or
+        item.category == Category.structure
+    ),
     Skill: lambda item: item.category == Category.skill,
     Stance: lambda item: item.group == Group.ship_modifier,
     Subsystem: lambda item: (

--- a/eos/fit/restriction_tracker/register/holder_class.py
+++ b/eos/fit/restriction_tracker/register/holder_class.py
@@ -49,23 +49,31 @@ CLASS_VALIDATORS = {
         Attribute.implantness in item.attributes
     ),
     ModuleHigh: lambda item: (
-        (item.category == Category.module or
-         item.category == Category.structureModule) and
+        (
+            item.category == Category.module or
+            item.category == Category.structureModule
+         ) and
         Slot.module_high in item.slots
     ),
     ModuleMed: lambda item: (
-        (item.category == Category.module or
-         item.category == Category.structureModule) and
+        (
+            item.category == Category.module or
+            item.category == Category.structureModule
+         ) and
         Slot.module_med in item.slots
     ),
     ModuleLow: lambda item: (
-        (item.category == Category.module or
-         item.category == Category.structureModule) and
+        (
+            item.category == Category.module or
+            item.category == Category.structureModule
+         ) and
         Slot.module_low in item.slots
     ),
     Rig: lambda item: (
-        (item.category == Category.module or
-         item.category == Category.structureModule) and
+        (
+            item.category == Category.module or
+            item.category == Category.structureModule
+        ) and
         Slot.rig in item.slots
     ),
     Ship: lambda item: (

--- a/eos/fit/restriction_tracker/register/ship_type_group.py
+++ b/eos/fit/restriction_tracker/register/ship_type_group.py
@@ -33,6 +33,9 @@ TYPE_RESTRICTION_ATTRS = (
     Attribute.can_fit_ship_type_2,
     Attribute.can_fit_ship_type_3,
     Attribute.can_fit_ship_type_4,
+    Attribute.can_fit_ship_type_5,
+    Attribute.can_fit_ship_type_6,
+    Attribute.can_fit_ship_type_7,
     Attribute.fits_to_shiptype
 )
 GROUP_RESTRICTION_ATTRS = (
@@ -43,7 +46,9 @@ GROUP_RESTRICTION_ATTRS = (
     Attribute.can_fit_ship_group_5,
     Attribute.can_fit_ship_group_6,
     Attribute.can_fit_ship_group_7,
-    Attribute.can_fit_ship_group_8
+    Attribute.can_fit_ship_group_8,
+    Attribute.can_fit_ship_group_9,
+    Attribute.can_fit_ship_group_10
 )
 
 

--- a/eos/fit/restriction_tracker/register/ship_type_group.py
+++ b/eos/fit/restriction_tracker/register/ship_type_group.py
@@ -36,7 +36,7 @@ TYPE_RESTRICTION_ATTRS = (
     Attribute.can_fit_ship_type_5,
     Attribute.can_fit_ship_type_6,
     Attribute.can_fit_ship_type_7,
-    Attribute.fits_to_shiptype
+    Attribute.fits_to_shiptype,
 )
 GROUP_RESTRICTION_ATTRS = (
     Attribute.can_fit_ship_group_1,
@@ -48,7 +48,7 @@ GROUP_RESTRICTION_ATTRS = (
     Attribute.can_fit_ship_group_7,
     Attribute.can_fit_ship_group_8,
     Attribute.can_fit_ship_group_9,
-    Attribute.can_fit_ship_group_10
+    Attribute.can_fit_ship_group_10,
 )
 
 


### PR DESCRIPTION
Requires #16 to be in place to work (both PRs touch `eve.py` but in different ways and for different reasons).

This enables structures to be calculated as a ship.  For all intents and purposes, the mechanics of structures *ARE* ships, they just have their own set of groups (and one special slot for services).

There are some validation issues with structures, but that's in different modules so needs to be cleared up in a seperate PR.  The structure itself validates correctly and without exception if you don't add any modules, the issue comes into play with some of the assumptions made for validation.

Known validation issues:
1) Structures are assumed to be subcaps with capital mods, so `capital_item.py` throws an exception.
2) Structure modules/rigs have no requirements, but an exception is thrown saying that the skills don't meet the requirements.