### PR TITLE
Capital Item Volume Validation

### DIFF
--- a/eos/const/eve.py
+++ b/eos/const/eve.py
@@ -115,6 +115,7 @@ class Attribute(IntEnum):
     rig_size = 1547
     allowed_drone_group_1 = 1782
     allowed_drone_group_2 = 1783
+    is_capital_size = 1785
     reload_time = 1795
     can_fit_ship_group_5 = 1872
     can_fit_ship_group_6 = 1879

--- a/eos/fit/restriction_tracker/register/capital_item.py
+++ b/eos/fit/restriction_tracker/register/capital_item.py
@@ -27,12 +27,13 @@ from eos.fit.restriction_tracker.exception import RegisterValidationError
 from .abc import RestrictionRegister
 
 
-# Holders of volume bigger than this
-# are considered as capital
-MAX_SUBCAP_VOLUME = 500
+# Capital items are exactly 4000 or 8000 in size
+# with the exception of a few officer modules
+# (which this validation will not catch)
+CapitalItemVolumeSize = [4000, 8000]
 
 
-CapitalItemErrorData = namedtuple('CapitalItemErrorData', ('holder_volume', 'max_allowed_volume'))
+CapitalItemErrorData = namedtuple('CapitalItemErrorData', ('holder_volume', 'capital_item_volumes'))
 
 
 class CapitalItemRegister(RestrictionRegister):
@@ -62,7 +63,7 @@ class CapitalItemRegister(RestrictionRegister):
             holder_volume = holder.item.attributes[Attribute.volume]
         except KeyError:
             return
-        if holder_volume <= MAX_SUBCAP_VOLUME:
+        if holder_volume not in CapitalItemVolumeSize:
             return
         self.__capital_holders.add(holder)
 
@@ -70,16 +71,23 @@ class CapitalItemRegister(RestrictionRegister):
         self.__capital_holders.discard(holder)
 
     def validate(self):
-        # Skip validation only if ship has capital
-        # ships requirement, else carry on
+
         ship_holder = self._fit.ship
         try:
             ship_item = ship_holder.item
         except AttributeError:
             pass
         else:
-            if Type.capital_ships in ship_item.required_skills:
+            if not ship_item.required_skills:
+                # There are no skills attached to the ship
+                # Return without tainting the holder
                 return
+
+            if Type.capital_ships in ship_item.required_skills:
+                # Skip validation only if ship has capital
+                # ships requirement, else carry on
+                return
+
         # If we got here, then we're dealing with non-capital
         # ship, and all registered holders are tainted
         if self.__capital_holders:
@@ -88,7 +96,7 @@ class CapitalItemRegister(RestrictionRegister):
                 holder_volume = holder.item.attributes[Attribute.volume]
                 tainted_holders[holder] = CapitalItemErrorData(
                     holder_volume=holder_volume,
-                    max_allowed_volume=MAX_SUBCAP_VOLUME
+                    capital_item_volumes=CapitalItemVolumeSize
                 )
             raise RegisterValidationError(tainted_holders)
 


### PR DESCRIPTION
Changed the code to better handle capital items.  All capital items in game are exactly 4000 or 8000 in volume, except for a handful of officer modules (which this validation will not catch).  The validation is skipped if the ship is a capital (since capital items are allowed) or if there are no requirements attached to the ship (since we don't know if it's a capital or not, we can't really validate it either way).

Tests need to be rewritten to handle that, will update the PR with the updated tests.